### PR TITLE
No clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,0 @@
-/Users/bgporter/personal/clang/bgp/.clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,5 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+.clang-format


### PR DESCRIPTION
Hi @bgporter 

There is a symlink at the root of the repo pointing to a system-specific directory:

`.clang-format -> /Users/bgporter/personal/clang/bgp/.clang-format`

This pull request suggests its removal and add it to gitignore, so you can still use it in your system.