### PR TITLE
Object::findOne()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 * 2024-05-01
+
+- Added new `Object::findOne()` method to search for and return a single child tree from an object. 
+- Added new argument `returnFirstFound` to `Query::search`, used to implement the above. 
+- 
+
 ## 1.3.1 * 2024-03-29
 
 - Cleaned up some buggy unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added new `Object::findOne()` method to search for and return a single child tree from an object. 
 - Added new argument `returnFirstFound` to `Query::search`, used to implement the above. 
-- 
+- Fixed some compiler warnings. 
 
 ## 1.3.1 * 2024-03-29
 

--- a/cello.h
+++ b/cello.h
@@ -24,7 +24,7 @@
 BEGIN_JUCE_MODULE_DECLARATION
  ID:               cello
  vendor:           Brett g Porter
- version:          1.2.0
+ version:          1.4.0
  name:             Cello
  description:      Classes for working with JUCE Value Trees
  website:          https://github.com/bgporter/cello

--- a/cello/cello_ipc.cpp
+++ b/cello/cello_ipc.cpp
@@ -183,7 +183,7 @@ IpcServer::IpcServer (Object& sync, IpcClient::UpdateType updateType, const juce
     // the server properties will change its portNumber member to let us
     // know that we should start or stop ourselves.
     serverProperties.portNumber.onPropertyChange (
-        [this] (juce::Identifier id)
+        [this] (juce::Identifier /*id*/)
         {
             if (serverProperties.portNumber > 0)
                 startServer (serverProperties.portNumber, serverProperties.bindAddress);

--- a/cello/cello_object.cpp
+++ b/cello/cello_object.cpp
@@ -25,8 +25,7 @@ namespace cello
 {
 
 Object::Object (const juce::String& type, const Object* state)
-: Object { type, (state != nullptr ? static_cast<juce::ValueTree> (*state)
-                                   : juce::ValueTree ()) }
+: Object { type, (state != nullptr ? static_cast<juce::ValueTree> (*state) : juce::ValueTree ()) }
 {
     if (state != nullptr)
         undoManager = state->getUndoManager ();
@@ -89,13 +88,17 @@ juce::ValueTree Object::clone (bool deep) const
 
 void Object::update (const juce::MemoryBlock& updateBlock)
 {
-    juce::ValueTreeSynchroniser::applyChange (data, updateBlock.getData (),
-                                              updateBlock.getSize (), getUndoManager ());
+    juce::ValueTreeSynchroniser::applyChange (data, updateBlock.getData (), updateBlock.getSize (), getUndoManager ());
 }
 
 juce::ValueTree Object::find (const cello::Query& query, bool deep)
 {
-    return query.search (data, deep);
+    return query.search (data, deep, false);
+}
+
+juce::ValueTree Object::findOne (const cello::Query& query, bool deep)
+{
+    return query.search (data, deep, true);
 }
 
 bool Object::upsert (const Object* object, const juce::Identifier& key, bool deep)
@@ -322,8 +325,7 @@ juce::Result Object::save (juce::File file, FileFormat format) const
     if (!fos.openedOk ())
     {
         jassertfalse;
-        return juce::Result::fail ("Unable to open " + file.getFullPathName () +
-                                   " for writing");
+        return juce::Result::fail ("Unable to open " + file.getFullPathName () + " for writing");
     }
 
     if (format == FileFormat::binary)
@@ -393,8 +395,7 @@ Object::CreationType Object::wrap (const juce::String& type, juce::ValueTree tre
     return creationType;
 }
 
-void Object::valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged,
-                                       const juce::Identifier& property)
+void Object::valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged, const juce::Identifier& property)
 {
     if (treeWhosePropertyHasChanged == data)
     {
@@ -422,15 +423,13 @@ void Object::valueTreeChildAdded (juce::ValueTree& parentTree, juce::ValueTree& 
         onChildAdded (childTree, -1, data.indexOf (childTree));
 }
 
-void Object::valueTreeChildRemoved (juce::ValueTree& parentTree,
-                                    juce::ValueTree& childTree, int index)
+void Object::valueTreeChildRemoved (juce::ValueTree& parentTree, juce::ValueTree& childTree, int index)
 {
     if (parentTree == data && onChildRemoved != nullptr)
         onChildRemoved (childTree, index, -1);
 }
 
-void Object::valueTreeChildOrderChanged (juce::ValueTree& parentTree, int oldIndex,
-                                         int newIndex)
+void Object::valueTreeChildOrderChanged (juce::ValueTree& parentTree, int oldIndex, int newIndex)
 {
     if (parentTree == data && onChildMoved != nullptr)
     {

--- a/cello/cello_object.h
+++ b/cello/cello_object.h
@@ -97,8 +97,7 @@ public:
      * @param file
      * @param format
      */
-    Object (const juce::String& type, juce::File file,
-            FileFormat format = FileFormat::xml);
+    Object (const juce::String& type, juce::File file, FileFormat format = FileFormat::xml);
 
     /**
      * @brief Construct a new Object object as a copy of an existing one.
@@ -205,6 +204,17 @@ public:
      * @return juce::ValueTree
      */
     juce::ValueTree find (const cello::Query& query, bool deep = false);
+
+    /**
+     * @brief Perform a query against the children of this object, returning
+     * the a copy of the first child found that meets the predicates in the
+     * query object, or an empty tree if none is found.
+     *
+     * @param query Query object that defines the search/sort criteria
+     * @param deep if true, also copy sub-items from object.
+     * @return juce::ValueTree copy of a matching child tree or {}
+     */
+    juce::ValueTree findOne (const cello::Query& query, bool deep = false);
 
     /**
      * @brief Update or insert a child object (concept borrowed from MongoDB)
@@ -384,10 +394,7 @@ public:
      *
      * @param listener
      */
-    void excludeListener (juce::ValueTree::Listener* listener)
-    {
-        excludedListener = listener;
-    }
+    void excludeListener (juce::ValueTree::Listener* listener) { excludedListener = listener; }
 
     /**
      * @brief Get a pointer to the listener to exclude from property change updates.
@@ -421,8 +428,7 @@ public:
      */
     void onPropertyChange (const ValueBase& val, PropertyUpdateFn callback);
 
-    using ChildUpdateFn =
-        std::function<void (juce::ValueTree& child, int oldIndex, int newIndex)>;
+    using ChildUpdateFn = std::function<void (juce::ValueTree& child, int oldIndex, int newIndex)>;
 
     ChildUpdateFn onChildAdded;
     ChildUpdateFn onChildRemoved;
@@ -456,8 +462,7 @@ public:
      * @param defaultVal
      * @return T
      */
-    template <typename T>
-    T getattr (const juce::Identifier& attr, const T& defaultVal) const
+    template <typename T> T getattr (const juce::Identifier& attr, const T& defaultVal) const
     {
         return juce::VariantConverter<T>::fromVar (data.getProperty (attr, defaultVal));
     }
@@ -481,8 +486,7 @@ public:
      */
     template <typename T> Object& setattr (const juce::Identifier& attr, const T& attrVal)
     {
-        data.setProperty (attr, juce::VariantConverter<T>::toVar (attrVal),
-                          getUndoManager ());
+        data.setProperty (attr, juce::VariantConverter<T>::toVar (attrVal), getUndoManager ());
         return (*this);
     }
 
@@ -553,8 +557,7 @@ private:
      * @param parentTree
      * @param childTree
      */
-    void valueTreeChildAdded (juce::ValueTree& parentTree,
-                              juce::ValueTree& childTree) override;
+    void valueTreeChildAdded (juce::ValueTree& parentTree, juce::ValueTree& childTree) override;
 
     /**
      * @brief Will execute the callback `onChildRemoved` if it exists.
@@ -563,8 +566,7 @@ private:
      * @param childTree
      * @param index
      */
-    void valueTreeChildRemoved (juce::ValueTree& parentTree, juce::ValueTree& childTree,
-                                int index) override;
+    void valueTreeChildRemoved (juce::ValueTree& parentTree, juce::ValueTree& childTree, int index) override;
 
     /**
      * @brief will execute the callback `onChildMoved` if it exists.
@@ -573,8 +575,7 @@ private:
      * @param oldIndex
      * @param newIndex
      */
-    void valueTreeChildOrderChanged (juce::ValueTree& childTree, int oldIndex,
-                                     int newIndex) override;
+    void valueTreeChildOrderChanged (juce::ValueTree& childTree, int oldIndex, int newIndex) override;
 
     /**
      * @brief Will execute the `onParentChanged` callback if it exists.

--- a/cello/cello_query.cpp
+++ b/cello/cello_query.cpp
@@ -38,7 +38,7 @@ Query& Query::addFilter (Predicate filter)
     return *this;
 }
 
-juce::ValueTree Query::search (juce::ValueTree tree, bool deep) const
+juce::ValueTree Query::search (juce::ValueTree tree, bool deep, bool returnFirstFound) const
 {
     juce::ValueTree result { type };
     for (auto child : tree)
@@ -50,9 +50,15 @@ juce::ValueTree Query::search (juce::ValueTree tree, bool deep) const
                 childCopy.copyPropertiesAndChildrenFrom (child, nullptr);
             else
                 childCopy.copyPropertiesFrom (child, nullptr);
+            if (returnFirstFound)
+                return childCopy;
             result.appendChild (childCopy, nullptr);
         }
     }
+
+    if (returnFirstFound)
+        return {};
+
     return sort (result);
     // return result;
 }

--- a/cello/cello_query.h
+++ b/cello/cello_query.h
@@ -38,8 +38,7 @@ public:
     // return 0 if the two trees should sort equally.
     // return -1 if left should come before right
     // return +1 if right should come before left.
-    using Comparison =
-        std::function<int (const juce::ValueTree&, const juce::ValueTree&)>;
+    using Comparison = std::function<int (const juce::ValueTree&, const juce::ValueTree&)>;
 
     /**
      * @brief Construct a new Query object.
@@ -82,10 +81,12 @@ public:
      *
      * @param tree ValueTree to search.
      * @param deep  If true, the result tree will contain a deep copy of each
-     *      chid found.
+     *      child found.
+     * @param returnFirstFound If true, will return a copy of the first matching
+     *      child found, or an invalid tree if none was found.
      * @return juce::ValueTree with query results.
      */
-    juce::ValueTree search (juce::ValueTree tree, bool deep) const;
+    juce::ValueTree search (juce::ValueTree tree, bool deep, bool returnFirstFound = false) const;
 
     /**
      * @brief Add a comparison function to the list we use to sort a list
@@ -106,8 +107,7 @@ public:
      *      equal. This is slower, so only use it if needed.
      * @return juce::ValueTree
      */
-    juce::ValueTree sort (juce::ValueTree tree, juce::UndoManager* undo = nullptr,
-                          bool stableSort = false) const;
+    juce::ValueTree sort (juce::ValueTree tree, juce::UndoManager* undo = nullptr, bool stableSort = false) const;
 
 private:
     /**

--- a/cello/cello_sync.h
+++ b/cello/cello_sync.h
@@ -32,7 +32,7 @@ class UpdateQueue
 {
 public:
     UpdateQueue (Object& consumer, juce::Thread* thread);
-    virtual ~UpdateQueue () {};
+    virtual ~UpdateQueue () {}
     UpdateQueue (const UpdateQueue&)            = delete;
     UpdateQueue& operator= (const UpdateQueue&) = delete;
     UpdateQueue (UpdateQueue&&)                 = delete;

--- a/cello/cello_value.h
+++ b/cello/cello_value.h
@@ -151,8 +151,7 @@ public:
         {
             // when the underlying value changes, cache it here so it can
             // be used without needing to look it up, go through validation, etc.
-            value.onPropertyChange ([this] (juce::Identifier id)
-                                    { cachedValue = static_cast<T> (value); });
+            value.onPropertyChange ([this] (juce::Identifier /*id*/) { cachedValue = static_cast<T> (value); });
         }
 
         ~Cached () { value.onPropertyChange (nullptr); }
@@ -195,10 +194,7 @@ public:
      *
      * @param listener
      */
-    void excludeListener (juce::ValueTree::Listener* listener)
-    {
-        excludedListener = listener;
-    }
+    void excludeListener (juce::ValueTree::Listener* listener) { excludedListener = listener; }
 
     /**
      * @brief Register (or clear) a callback function to execute when this value
@@ -206,10 +202,7 @@ public:
      *
      * @param callback
      */
-    void onPropertyChange (PropertyUpdateFn callback)
-    {
-        object.onPropertyChange (getId (), callback);
-    }
+    void onPropertyChange (PropertyUpdateFn callback) { object.onPropertyChange (getId (), callback); }
 
 private:
     void doSet (const T& val)
@@ -221,13 +214,10 @@ private:
         {
             // check if this value or our parent object have a listener to exclude
             // from updates.
-            auto* excluded = (excludedListener != nullptr)
-                                 ? excludedListener
-                                 : object.getExcludedListener ();
+            auto* excluded = (excludedListener != nullptr) ? excludedListener : object.getExcludedListener ();
             const auto asVar { juce::VariantConverter<T>::toVar (val) };
             if (excluded)
-                tree.setPropertyExcludingListener (excluded, id, asVar,
-                                                   object.getUndoManager ());
+                tree.setPropertyExcludingListener (excluded, id, asVar, object.getUndoManager ());
             else
                 tree.setProperty (id, asVar, object.getUndoManager ());
         }

--- a/cello/test/test_cello_query.inl
+++ b/cello/test/test_cello_query.inl
@@ -147,6 +147,24 @@ public:
                   expectEquals (loResult.getNumChildren () + hiResult.getNumChildren (), root.getNumChildren ());
               });
 
+        test ("select one",
+              [this] ()
+              {
+                  cello::Object root { "root", parentTree };
+                 // look for a key in the previous 100
+                  int target = Data::lastKey - 50;
+                  cello::Query half (
+                      [this, target] (juce::ValueTree tree)
+                      {
+                          Data d { tree };
+                          return (d.key == target);
+                      });
+                  auto found { root.findOne (half, false) };
+                  expect (found.isValid ());
+                  Data foundData { found };
+                  expect (foundData.key == target);
+              });
+
         test ("multiple predicates",
               [this] ()
               {


### PR DESCRIPTION
- Add `Object::findOne` method to avoid searching through all children once you've found a unique item you're looking for. 
- Corrected some compiler warnings. 
- bumped version to 1.4.0 
- Some reformatting; apologies for the noise. 