### PR TITLE
Cello 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased 
+## 1.5.0 * 2025-02-09 
 
 ### Added 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+### Added 
+
+- TODO: add `get()` method to value, simplfying accessing the underlying data of a `Value` in its correct compile-time type. 
+- TODO: fix behavior of listeners on an Object's type to return the ID of the property that has changed, not the ID of the tree itself, which isn't that useful. 
+  
+
 ## 1.4.0 * 2024-05-01
 
 - Added new `Object::findOne()` method to search for and return a single child tree from an object. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
-- TODO: add `get()` method to value, simplfying accessing the underlying data of a `Value` in its correct compile-time type. 
-- TODO: fix behavior of listeners on an Object's type to return the ID of the property that has changed, not the ID of the tree itself, which isn't that useful. 
-  
+- add `get()` method to value, simplfying accessing the underlying data of a `Value` in its correct compile-time type. 
+- fix behavior of listeners on an Object's type to return the ID of the property that has changed, not the ID of the tree itself, which isn't that useful. 
+- add `Object::wasWrapped()` and `Object::wasInitialized()` methods. 
+- add `Object::getTypeName()` for convenience. 
+- add `Object::toXmlString()` for convenience. 
 
 ## 1.4.0 * 2024-05-01
 

--- a/cello/cello_object.cpp
+++ b/cello/cello_object.cpp
@@ -349,46 +349,12 @@ juce::Result Object::save (juce::File file, FileFormat format) const
 Object::CreationType Object::wrap (const juce::String& type, juce::ValueTree tree)
 {
     creationType = CreationType::wrapped;
-#if PATH_IMPL
     Path path { type };
     // DBG(tree.toXmlString());
     data = path.findValueTree (tree, Path::SearchType::createAll, nullptr);
     // DBG(data.toXmlString());
     if (path.getSearchResult () == Path::SearchResult::created)
         creationType = CreationType::initialized;
-#else
-    if (tree.isValid ())
-    {
-        // case 1: We're passed the tree we use as our store directly.
-        if (tree.getType () == type)
-            data = tree;
-        else
-        {
-            // case 2: look in the state tree for our data.
-            auto childTree = tree.getChildWithName (type);
-            if (childTree.isValid ())
-            {
-                data = childTree;
-            }
-            else
-            {
-                // case 3: the state tree doesn't have a tree for our data type
-                // yet. Create an empty tree of the correct type, mark ourselves
-                // as having been default-initialized.
-                data         = juce::ValueTree (type);
-                creationType = CreationType::initialized;
-                tree.appendChild (data, getUndoManager ());
-            }
-        }
-    }
-    else
-    {
-        // case 4: There's no state, just create an empty tree of the correct
-        // type and mark ourselves as needing to be initialized.
-        data         = juce::ValueTree (type);
-        creationType = CreationType::initialized;
-    }
-#endif
 
     // register to receive callbacks when the tree changes.
     data.addListener (this);
@@ -397,24 +363,29 @@ Object::CreationType Object::wrap (const juce::String& type, juce::ValueTree tre
 
 void Object::valueTreePropertyChanged (juce::ValueTree& treeWhosePropertyHasChanged, const juce::Identifier& property)
 {
-    if (treeWhosePropertyHasChanged == data)
+    if (treeWhosePropertyHasChanged != data)
+        return;
+    // look for an update callback for this property. Returns true if a callback
+    // was registered and called.
+    auto callUpdaterForProperty = [this] (const juce::Identifier& key, const juce::Identifier& prop) -> bool
     {
-        // first, try to find a callback for that exact property.
         for (const auto& updater : propertyUpdaters)
         {
-            if (updater.id == property)
+            if (updater.id == key)
             {
                 if (updater.fn != nullptr)
-                    updater.fn (property);
-                return;
+                    updater.fn (prop);
+                return true;
             }
         }
-        // a cello extension: register a callback on the name of the tree's
-        // type, and you'll get a callback there for any property change that
-        // didn't have its own callback registered.
-        if (property != getType ())
-            valueTreePropertyChanged (data, getType ());
-    }
+        return false;
+    };
+
+    // first, try to find a callback for that exact property.
+    if (callUpdaterForProperty (property, property))
+        return;
+    // ...then see if a generic callback is registered for the type of the tree.
+    callUpdaterForProperty (getType (), property);
 }
 
 void Object::valueTreeChildAdded (juce::ValueTree& parentTree, juce::ValueTree& childTree)

--- a/cello/cello_object.h
+++ b/cello/cello_object.h
@@ -147,11 +147,29 @@ public:
     bool operator!= (const juce::ValueTree& rhs) const noexcept { return data != rhs; }
 
     /**
-     * @brief Get the type of this object.
+     * @brief Get the type of this object as a juce::Identifier.
      *
      * @return juce::Identifier
      */
     juce::Identifier getType () const { return data.getType (); }
+
+    /**
+     * @brief Get the type of this object as a string.
+     *
+     * @return juce::String
+     */
+    juce::String getTypeName () const { return getType ().toString (); }
+
+    /**
+     * @brief Generate a string representation of this object's tree.
+     *
+     * @param format specifies details of the output.
+     * @return juce::String
+     */
+    juce::String toXmlString (const juce::XmlElement::TextFormat& format = {}) const
+    {
+        return data.toXmlString (format);
+    }
 
     /**
      * @brief Determine how this object was created, which will be one of:
@@ -165,6 +183,20 @@ public:
      * @return CreationType
      */
     CreationType getCreationType () const { return creationType; }
+
+    /**
+     * @brief utility method to test the creation type as a bool.
+     *
+     * @return true if this object was created by wrapping an existing tree.
+     */
+    bool wasWrapped () const { return creationType == CreationType::wrapped; }
+
+    /**
+     * @brief utility method to test the creation type as a bool.
+     *
+     * @return true if this object was created by default initialization.
+     */
+    bool wasInitialized () const { return creationType == CreationType::initialized; }
 
     /**
      * @brief Get the ValueTree we're using as our data store.
@@ -207,7 +239,7 @@ public:
 
     /**
      * @brief Perform a query against the children of this object, returning
-     * the a copy of the first child found that meets the predicates in the
+     * a copy of the first child found that meets the predicates in the
      * query object, or an empty tree if none is found.
      *
      * @param query Query object that defines the search/sort criteria
@@ -418,6 +450,15 @@ public:
      * @param callback function to call on update.
      */
     void onPropertyChange (juce::Identifier id, PropertyUpdateFn callback);
+
+    /**
+     * @brief install or clear a generic callback that will be called when any
+     * property in the object changes. The identifier of the property that changed
+     * will be passed to the callback.
+     *
+     * @param callback
+     */
+    void onPropertyChange (PropertyUpdateFn callback) { onPropertyChange (getType (), callback); }
 
     /**
      * @brief register a property change callback by passing in a reference

--- a/cello/cello_path.h
+++ b/cello/cello_path.h
@@ -64,7 +64,7 @@ public:
     {
         query,        ///< only search, do not create anything.
         createTarget, ///< create final tree in specification, but no intermediate trees
-        createAll ///< create final tree and all intermediate trees needed to reach it.
+        createAll     ///< create final tree and all intermediate trees needed to reach it.
     };
 
     enum SearchResult
@@ -82,8 +82,7 @@ public:
      * @param searchType
      * @return juce::ValueTree; if search type was `query` may be an invalid tree
      */
-    juce::ValueTree findValueTree (juce::ValueTree& origin, SearchType searchType,
-                                   juce::UndoManager* undo = nullptr);
+    juce::ValueTree findValueTree (juce::ValueTree& origin, SearchType searchType, juce::UndoManager* undo = nullptr);
 
     /**
      * @brief Find out whether performing a search succeeded, and if so, needed to

--- a/cello/cello_value.h
+++ b/cello/cello_value.h
@@ -62,6 +62,12 @@ protected:
  * - be supported by the `juce::var` type, or define a
  *   `juce::VariantConverter` structure to round-trip through a `juce::var`
  *
+ * **NOTE** that we have a special case for floating point types -- we compare
+ * the old and new versions of the value with a small epsilon value to let your
+ * code control how 'close' two floating point values must be to be considered
+ * equivalent. There's a static `epsilon` member of this class that you can
+ * set as needed in your application; the default is 0.001.
+ *
  * @tparam T Data type handled by this Value.
  */
 template <typename T> class Value : public ValueBase
@@ -184,6 +190,7 @@ public:
      * retrieved.
      */
     using ValidatePropertyFn = std::function<T (const T&)>;
+
     /**
      * @brief validator function called before setting this Value.
      */
@@ -232,8 +239,7 @@ private:
         {
             // check if we or our parent object want us to always send
             // a property change callback for this value.
-            const auto forceUpdate = shouldForceUpdate () || object.shouldForceUpdate ();
-            if (forceUpdate)
+            if (shouldForceUpdate () || object.shouldForceUpdate ())
                 tree.sendPropertyChangeMessage (id);
         }
     }
@@ -260,8 +266,8 @@ private:
     }
 
 public:
-    /// when setting, delta must be larger than this to cause a property
-    /// change callback.
+    /// when setting a floating point value, delta must be larger than this to
+    /// cause a property change callback.
     static inline float epsilon { 0.001f };
 
 private:
@@ -365,7 +371,11 @@ T operator-- (Value<T>& val)
 }
 
 /**
- * @brief post-decrement;
+ * @brief post-decrement; note that the semantics of this don't follow 'real'
+ * C++ usage -- because this type relies on an underlying ValueTree object to
+ * provide the actual data storage, the idea of 'returning a copy of this object
+ * in its original state' doesn't work. Instead, we return an instance of the
+ * `T` data type itself.
  *
  * @tparam T
  * @tparam std::enable_if<std::is_arithmetic<T>::value, T>::type

--- a/cello/cello_value.h
+++ b/cello/cello_value.h
@@ -120,7 +120,14 @@ public:
      *
      * @return T
      */
-    operator T () const
+    operator T () const { return get (); }
+
+    /**
+     * @brief Get the current value of this property from the tree.
+     *
+     * @return T
+     */
+    T get () const
     {
         if (onGet != nullptr)
             return onGet (doGet ());

--- a/cello/test/test_cello_object.inl
+++ b/cello/test/test_cello_object.inl
@@ -271,6 +271,34 @@ public:
                   expect (count == 1);
                   pt.y = -50;
                   expect (count == 2);
+
+                  juce::Identifier lastIdentifier;
+                  int lastValue { 0 };
+                  cello::PropertyUpdateFn callback2 = [&pt, &lastIdentifier, &lastValue] (juce::Identifier id)
+                  {
+                      lastIdentifier = id;
+                      lastValue      = pt.getattr<int> (id, 0);
+                  };
+
+                  pt.onPropertyChange (pt.getType (), callback2);
+                  // the generic callback should not be called because `pt` has
+                  // handlers for both x and y.
+                  pt.x = 200;
+                  expect (lastIdentifier.isNull ());
+                  expect (lastValue == 0);
+                  pt.y = 200;
+                  expect (lastIdentifier.isNull ());
+                  expect (lastValue == 0);
+            
+                  Vec2 pt2 = pt;
+                  // install the generic callback on pt2
+                  pt2.onPropertyChange (callback2);
+                  pt.x = 201;
+                  expect (lastIdentifier.toString () == "x");
+                  expect (lastValue == 201);
+                  pt.y = 1201;
+                  expect (lastIdentifier.toString () == "y");
+                  expect (lastValue == 1201);
               });
         test ("force updates",
               [&] ()

--- a/cello/test/test_cello_value.inl
+++ b/cello/test/test_cello_value.inl
@@ -137,10 +137,13 @@ public:
                   o.complexVal = orig;
 
                   std::complex<float> retrieved { o.complexVal };
-                  expectWithinAbsoluteError<float> (orig.real (), retrieved.real (),
-                                                    0.001f);
-                  expectWithinAbsoluteError<float> (orig.imag (), retrieved.imag (),
-                                                    0.001f);
+                  expectWithinAbsoluteError<float> (orig.real (), retrieved.real (), 0.001f);
+                  expectWithinAbsoluteError<float> (orig.imag (), retrieved.imag (), 0.001f);
+
+                  // test using the `get()` method into an `auto` variable
+                  auto retrieved2 { o.complexVal.get () };
+                  expectWithinAbsoluteError<float> (orig.real (), retrieved2.real (), 0.001f);
+                  expectWithinAbsoluteError<float> (orig.imag (), retrieved2.imag (), 0.001f);
               });
 
         test ("Cached value",


### PR DESCRIPTION
- add `get()` method to value, simplfying accessing the underlying data of a `Value` in its correct compile-time type. 
- fix behavior of listeners on an Object's type to return the ID of the property that has changed, not the ID of the tree itself, which isn't that useful. 
- add `Object::wasWrapped()` and `Object::wasInitialized()` methods. 
- add `Object::getTypeName()` for convenience. 
- add `Object::toXmlString()` for convenience. 